### PR TITLE
Fixing the Czech translation of "disconnect".

### DIFF
--- a/cs_CZ/strings.xml
+++ b/cs_CZ/strings.xml
@@ -321,7 +321,7 @@
     <string name="port_forwards">Přesměrování portů</string>
     <string name="no_port_forwards">Žádná přesměrování portů</string>
     <string name="you_do_not_have_any_port_forwards">Nemáte nakonfigurována žádná přesměrování portů</string>
-    <string name="disconnect">Odpojeno</string>
+    <string name="disconnect">Odpojit</string>
     <string name="socks_forward_description">Dynamické SOCKS na portu %s</string>
     <string name="new_port_forward">Nové přesměrování portů</string>
     <string name="update_port_forward">Aktualizovat přesměrování portů</string>


### PR DESCRIPTION
`odpojeno == disconnected`
`odpojit == disconnect`

The JuiceSSH notification in the Android notification drawer shows (what translates to) "disconnected". This creates confusion: Why am I disconnected? What went wrong? It turns out that this is in fact a clickable link / button one can use to disconnect. It is **not** an announcement that the session has disconnected. :smile: